### PR TITLE
feature(#2): Kakao 지도 렌더링 기능 추가

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Motivation
+
+-
+
+<br>
+
+## Key Changes
+
+-
+
+<br>
+
+## To Reviewers
+

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,11 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.8.2",
     "next": "15.3.5",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-redux": "^9.2.0",
+    "redux": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@reduxjs/toolkit':
+        specifier: ^2.8.2
+        version: 2.8.2(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       next:
         specifier: 15.3.5
         version: 15.3.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -17,6 +20,12 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-redux:
+        specifier: ^9.2.0
+        version: 9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1)
+      redux:
+        specifier: ^5.0.1
+        version: 5.0.1
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -336,11 +345,28 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@reduxjs/toolkit@2.8.2':
+    resolution: {integrity: sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -458,6 +484,9 @@ packages:
 
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.35.1':
     resolution: {integrity: sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==}
@@ -1110,6 +1139,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.1.1:
+    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1543,9 +1575,29 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1554,6 +1606,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1780,6 +1835,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2050,9 +2110,25 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@standard-schema/utils': 0.3.0
+      immer: 10.1.1
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.1.0
+      react-redux: 9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
+
+  '@standard-schema/spec@1.0.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -2154,6 +2230,8 @@ snapshots:
   '@types/react@19.1.8':
     dependencies:
       csstype: 3.1.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
@@ -2986,6 +3064,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.1.1: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3401,7 +3481,22 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      redux: 5.0.1
+
   react@19.1.0: {}
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3422,6 +3517,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -3746,6 +3843,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/StoreProvider.tsx
+++ b/src/app/StoreProvider.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { AppStore, makeStore } from "lib/store";
+import { useRef } from "react";
+import { Provider } from "react-redux";
+
+export default function StoreProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const storeRef = useRef<AppStore | null>(null);
+
+  if (!storeRef.current) {
+    storeRef.current = makeStore();
+  }
+
+  return <Provider store={storeRef.current}>{children}</Provider>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import StoreProvider from "./StoreProvider";
 
 export const metadata: Metadata = {
   title: "Semi Map",
@@ -13,7 +14,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <StoreProvider>
+        <body>{children}</body>
+      </StoreProvider>
     </html>
   );
 }

--- a/src/app/map/[slug]/page.tsx
+++ b/src/app/map/[slug]/page.tsx
@@ -1,0 +1,8 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  return <div>My Post: {slug}</div>;
+}

--- a/src/app/map/layout.tsx
+++ b/src/app/map/layout.tsx
@@ -1,12 +1,46 @@
+"use client";
+
 import Script from "next/script";
+import { useEffect, useRef } from "react";
+
+import {
+  sdkLoadFail,
+  sdkLoadSuccess,
+  selectSdkLoaded,
+} from "features/kakaoMap/kakaoMapSlice";
+import { useAppDispatch, useAppSelector } from "lib/hooks";
+import { styles } from "@/styles/index";
 
 export default function MapLayout({ children }: { children: React.ReactNode }) {
+  const mapRef = useRef<HTMLDivElement | null>(null);
+
+  const dispatch = useAppDispatch();
+  const sdkLoaded = useAppSelector(selectSdkLoaded);
+
+  useEffect(() => {
+    console.log("sdkLoaded changed:", sdkLoaded);
+
+    if (!sdkLoaded || !window.kakao?.maps || !mapRef.current) return;
+
+    window.kakao.maps.load(() => {
+      const options = {
+        center: new window.kakao.maps.LatLng(33.450701, 126.570667),
+        level: 3,
+      };
+
+      const map = new window.kakao.maps.Map(mapRef.current, options);
+    });
+  }, [sdkLoaded]);
+
   return (
     <>
-      <section>{children}</section>
+      <div ref={mapRef} className={styles.map} />
+      {children}
       <Script
         src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_KEY}&libraries=services&autoload=false`}
-        strategy="beforeInteractive"
+        strategy="afterInteractive"
+        onLoad={() => dispatch(sdkLoadSuccess())}
+        onError={() => dispatch(sdkLoadFail())}
       />
     </>
   );

--- a/src/app/map/layout.tsx
+++ b/src/app/map/layout.tsx
@@ -1,36 +1,11 @@
 "use client";
 
 import Script from "next/script";
-import { useEffect, useRef } from "react";
-
-import {
-  sdkLoadFail,
-  sdkLoadSuccess,
-  selectSdkLoaded,
-} from "features/kakaoMap/kakaoMapSlice";
-import { useAppDispatch, useAppSelector } from "lib/hooks";
+import { useSdkLoad } from "@/hooks/useSdkLoad";
 import { styles } from "@/styles/index";
 
 export default function MapLayout({ children }: { children: React.ReactNode }) {
-  const mapRef = useRef<HTMLDivElement | null>(null);
-
-  const dispatch = useAppDispatch();
-  const sdkLoaded = useAppSelector(selectSdkLoaded);
-
-  useEffect(() => {
-    console.log("sdkLoaded changed:", sdkLoaded);
-
-    if (!sdkLoaded || !window.kakao?.maps || !mapRef.current) return;
-
-    window.kakao.maps.load(() => {
-      const options = {
-        center: new window.kakao.maps.LatLng(33.450701, 126.570667),
-        level: 3,
-      };
-
-      const map = new window.kakao.maps.Map(mapRef.current, options);
-    });
-  }, [sdkLoaded]);
+  const { mapRef, scriptLoadSuccess, scriptLoadFail } = useSdkLoad();
 
   return (
     <>
@@ -38,9 +13,8 @@ export default function MapLayout({ children }: { children: React.ReactNode }) {
       {children}
       <Script
         src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_KEY}&libraries=services&autoload=false`}
-        strategy="afterInteractive"
-        onLoad={() => dispatch(sdkLoadSuccess())}
-        onError={() => dispatch(sdkLoadFail())}
+        onLoad={scriptLoadSuccess}
+        onError={scriptLoadFail}
       />
     </>
   );

--- a/src/app/map/layout.tsx
+++ b/src/app/map/layout.tsx
@@ -1,0 +1,13 @@
+import Script from "next/script";
+
+export default function MapLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <section>{children}</section>
+      <Script
+        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_KEY}&libraries=services&autoload=false`}
+        strategy="beforeInteractive"
+      />
+    </>
+  );
+}

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-declare global {
-  interface Window {
-    kakao: any;
-  }
-}
+import Link from "next/link";
 
 export default function Map() {
-  return <>Map</>;
+  return (
+    <>
+      <Link href={"/map/1"}>1</Link>
+      <Link href={"/map/2"}>2</Link>
+      <Link href={"/map/3"}>3</Link>
+    </>
+  );
 }

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { styles } from "@/styles/index";
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+export default function Map() {
+  const mapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    window.kakao.maps.load(() => {
+      const options = {
+        center: new window.kakao.maps.LatLng(33.450701, 126.570667),
+        level: 3,
+      };
+
+      const map = new window.kakao.maps.Map(mapRef.current, options);
+    });
+  }, []);
+
+  return (
+    <div>
+      Map
+      <div ref={mapRef} className={styles.map} />
+    </div>
+  );
+}

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { styles } from "@/styles/index";
-
 declare global {
   interface Window {
     kakao: any;
@@ -10,23 +7,5 @@ declare global {
 }
 
 export default function Map() {
-  const mapRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    window.kakao.maps.load(() => {
-      const options = {
-        center: new window.kakao.maps.LatLng(33.450701, 126.570667),
-        level: 3,
-      };
-
-      const map = new window.kakao.maps.Map(mapRef.current, options);
-    });
-  }, []);
-
-  return (
-    <div>
-      Map
-      <div ref={mapRef} className={styles.map} />
-    </div>
-  );
+  return <>Map</>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,10 @@
+import Link from "next/link";
+
 export default function Home() {
-  return <div>Home</div>;
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-amber-100">
+      Home
+      <Link href={"/map"}>지도</Link>
+    </div>
+  );
 }

--- a/src/features/kakaoMap/kakaoMapSlice.ts
+++ b/src/features/kakaoMap/kakaoMapSlice.ts
@@ -1,0 +1,29 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { RootState } from "lib/store";
+
+export interface KakaoMapState {
+  isLoad: boolean;
+}
+
+const initialState: KakaoMapState = {
+  isLoad: false,
+};
+
+const kakaoMapSlice = createSlice({
+  name: "kakaoMap",
+  initialState,
+  reducers: {
+    sdkLoadSuccess: (state) => {
+      state.isLoad = true;
+    },
+    sdkLoadFail: (state) => {
+      state.isLoad = false;
+    },
+  },
+});
+
+export const { sdkLoadSuccess, sdkLoadFail } = kakaoMapSlice.actions;
+
+export const selectSdkLoaded = (state: RootState) => state.kakaoMap.isLoad;
+
+export default kakaoMapSlice.reducer;

--- a/src/hooks/useSdkLoad.ts
+++ b/src/hooks/useSdkLoad.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react";
+import {
+  sdkLoadFail,
+  sdkLoadSuccess,
+  selectSdkLoaded,
+} from "features/kakaoMap/kakaoMapSlice";
+import { useAppDispatch, useAppSelector } from "lib/hooks";
+
+export function useSdkLoad() {
+  const mapRef = useRef<HTMLDivElement | null>(null);
+
+  const sdkLoaded = useAppSelector(selectSdkLoaded);
+  const dispatch = useAppDispatch();
+
+  const scriptLoadSuccess = () => dispatch(sdkLoadSuccess());
+  const scriptLoadFail = () => dispatch(sdkLoadFail());
+
+  useEffect(() => {
+    if (!sdkLoaded || !window.kakao?.maps || !mapRef.current) return;
+
+    window.kakao.maps.load(() => {
+      const options = {
+        center: new window.kakao.maps.LatLng(33.450701, 126.570667),
+        level: 3,
+      };
+
+      const map = new window.kakao.maps.Map(mapRef.current, options);
+    });
+  }, [sdkLoaded]);
+
+  return {
+    mapRef,
+    scriptLoadSuccess,
+    scriptLoadFail,
+  };
+}

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,0 +1,5 @@
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "./store";
+
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,14 @@
+import { configureStore } from "@reduxjs/toolkit";
+import kakaoMapReducer from "../features/kakaoMap/kakaoMapSlice";
+
+export const makeStore = () => {
+  return configureStore({
+    reducer: {
+      kakaoMap: kakaoMapReducer,
+    },
+  });
+};
+
+export type AppStore = ReturnType<typeof makeStore>;
+export type RootState = ReturnType<AppStore["getState"]>;
+export type AppDispatch = AppStore["dispatch"];

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,5 @@
+export const styles = {
+  map: "w-[60rem] h-[40rem] rounded-lg shadow-md",
+  spinner: "absolute inset-0 flex items-center justify-center",
+  errorText: "mt-4 text-sm text-red-500",
+};


### PR DESCRIPTION
## Motivation

- 지도에 마커 표시 및 위치 검색 서비스를 구현하기 위해 Kakao SDK를 불러왔습니다.

<br>

## Key Changes

- `/map/{...}` 모든 경로에서 지도가 보이도록 레이아웃(`MapLayout.tsx`)에 스크립트를 추가해주었습니다.
- window, useRef의 참조값과 같이 브라우저 전용 객체에 접근하기 위해 useEffect 지연 로직을 사용했습니다.
- 외부 스크립트 로딩은 비동기이므로 SDK 로드 상태를 확인하고 지도를 생성하기 위한 조건을 추가했습니다. 이때, Redux를 사용해 로드 여부를 전역 상태로 관리했습니다.

<br>

## To Reviewers

- Redux에서 Zustand로 마이그레이션 예정입니다.
