### PR TITLE
ci(#7): Dockerfile 작성 및 nextjs 빌드 옵션 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+Dockerfile
+.dockerignore
+node_modules
+logs
+*.log
+pnpm-debug.log
+README.md
+.next
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# 1. 의존성 설치, 개발 및 빌드 환경 설정
+FROM node:18-alpine AS base
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json pnpm-lock.yaml*  ./
+RUN corepack enable pnpm && pnpm i --frozen-lockfile;
+
+# 2. Next.js 빌드
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN corepack enable pnpm && pnpm run build; 
+
+# 3. Next.js 실행
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[CHORE] Dockerfile 작성 #7 

## 📝 작업 내용

- [x] 이미지 빌드 명령어 `Dockerfile` 작성 (참고 링크 1번 순서대로)
- [x] `.dockerignore` 작성
- [x] 이미지 생성 `docker build -t semi-map .` 및 이미지 확인 `docker images`
- [x] 컨테이너 실행 `docker run -d -p 3000:3000 semi-map` (`-d` 옵션으로 백그라운드 실행)
- [x] 앱이 컨테이너 안에서 잘 작동함 확인 `docker ps`
- [x] 컨테이너 중지 `docker stop <CONTAINER_ID>`

### 스크린샷 (선택)

| <img width="877" height="740" alt="image" src="https://github.com/user-attachments/assets/bacf75c1-d048-407d-8565-0b93e17b2adb" /> | <img width="577" height="104" alt="image" src="https://github.com/user-attachments/assets/52cf432f-cb98-4210-a2f4-afc13282ecd6" /> | <img width="955" height="263" alt="image" src="https://github.com/user-attachments/assets/7c522566-5c7d-4a30-96c0-96bf89d128f9" /> |
|:--:|:--:|:--:|
| 빌드 | 빌드된 이미지 확인 | Docker desktop |

### 참고 링크
1. [Next.js 공식 문서](https://nextjs.org/docs/app/getting-started/deploying#docker) > [Next.js Docker Template](https://github.com/vercel/next.js/tree/canary/examples/with-docker) > [Dockerfile](https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile)
2. [Next.js 애플리케이션을 Dockerise 해보기](https://velog.io/@ewaterbin/Next.js-%EC%95%A0%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98%EC%9D%84-Dockerise-%ED%95%B4%EB%B3%B4%EA%B8%B0)

## 💬 리뷰 요구사항(선택)

Dockerfile 작성 시 현재 프로젝트의 패키지 매니저 pnpm에 맞춰 기존 코드를 수정하였습니다.

Dockerfile 작성 단계를 3단계로 나누었습니다.

1. 환경 설정 및 의존성 설치
- 노드 버전 20을 기반으로 한 경량 Linux alpine을 사용해 컨테이너 크기 최소화 및 필요한 런타임 환경 제공
- 명령어 실행 디렉터리 지정 및 별도의 lock 파일 생성 제어
2. Next.js 빌드
- 개발 소스 코드를 최적화된 프로덕션 코드로 변환
- 이전 단계에서 설치한 node_modules 종속성 복사 및 재사용하여 빌드 시간 단축
- 프로젝트의 모든 소스 파일을 컨테이너로 복사 및 애플리케이션 빌드함
3. Next.js 실행
- `next.config.js`의 output을 `standalone`으로 설정하여 최소한의 파일만`./next/standalone`로 출력
- `next.config.js`의 `standalone` 옵션: next의 빌드 아티팩트를 하나의 독립적인 모듈로 만들어주어 마이그레이션에 유용한 옵션. 모든 필요한 파일과 종속성이 한 디렉터리에 모아져 배포와 실행이 더 간편하다.

컨테이너 실행 시, 목적에 따라 다른 명령어를 사용할 수 있습니다.
- 서비스 배포용 컨테이너 실행: `docker run -d -p 3000:3000 semi-map`
- 테스트/디버깅 후 바로 종료하고 싶을 때: `docker run -it --rm -p 3000:3000 semi-map`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker 빌드를 최적화하기 위해 `.dockerignore` 파일이 추가되었습니다.
  * 멀티스테이지 Dockerfile이 도입되어 Next.js 애플리케이션의 빌드 및 실행 환경이 개선되었습니다.

* **Refactor**
  * Next.js 설정에서 빌드 출력 모드가 "standalone"으로 명시적으로 지정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->